### PR TITLE
Updated repository links after move

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-repository: sgrah-oss/shapkit
+repository: ThalesGroup/shapkit
 output: web
 topnav_title: shapkit
 site_title: shapkit

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -2,7 +2,7 @@ topnav:
 - title: Topnav
   items:
     - title: GitHub
-      external_url: https://github.com/simon.grah/shapkit_nbdev
+      external_url: https://github.com/ThalesGroup/shapkit
 
 #Topnav dropdowns
 topnav_dropdowns:

--- a/docs/inspector.html
+++ b/docs/inspector.html
@@ -59,7 +59,7 @@ description: "A closure called to update metrics after each iteration."
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="inspector" class="doc_header"><code>inspector</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/inspector.py#L35" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>inspector</code>(<strong><code>x_min</code></strong>, <strong><code>verbose</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="inspector" class="doc_header"><code>inspector</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/inspector.py#L35" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>inspector</code>(<strong><code>x_min</code></strong>, <strong><code>verbose</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>A closure called to update metrics after each iteration.</p>
 

--- a/docs/monte_carlo_shapley.html
+++ b/docs/monte_carlo_shapley.html
@@ -154,7 +154,7 @@ $$ z(\mathbf{x^*},\mathbf{r},S) = (z_1,\dots, z_d) \text{ with } z_i =  x_i^* \t
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="MonteCarloShapley" class="doc_header"><code>MonteCarloShapley</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/monte_carlo_shapley.py#L37" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>MonteCarloShapley</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>n_iter</code></strong>, <strong><code>callback</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="MonteCarloShapley" class="doc_header"><code>MonteCarloShapley</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/monte_carlo_shapley.py#L37" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>MonteCarloShapley</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>n_iter</code></strong>, <strong><code>callback</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Estimate the Shapley Values using an optimized Monte Carlo version.</p>
 

--- a/docs/plots.html
+++ b/docs/plots.html
@@ -59,7 +59,7 @@ description: "Plot function for displaying Shapley Values"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="plot_shapley" class="doc_header"><code>plot_shapley</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/plots.py#L40" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>plot_shapley</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>shapley_values</code></strong>, <strong><code>n_attributes</code></strong>, <strong><code>savefig</code></strong>=<em><code>False</code></em>, <strong><code>filename</code></strong>=<em><code>'fig.png'</code></em>, <strong><code>fig_format</code></strong>=<em><code>'png'</code></em>)</p>
+<h4 id="plot_shapley" class="doc_header"><code>plot_shapley</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/plots.py#L40" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>plot_shapley</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>shapley_values</code></strong>, <strong><code>n_attributes</code></strong>, <strong><code>savefig</code></strong>=<em><code>False</code></em>, <strong><code>filename</code></strong>=<em><code>'fig.png'</code></em>, <strong><code>fig_format</code></strong>=<em><code>'png'</code></em>)</p>
 </blockquote>
 
 </div>

--- a/docs/sgd_shapley.html
+++ b/docs/sgd_shapley.html
@@ -173,7 +173,7 @@ where</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ncr" class="doc_header"><code>ncr</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/sgd_shapley.py#L40" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ncr</code>(<strong><code>n</code></strong>, <strong><code>r</code></strong>)</p>
+<h4 id="ncr" class="doc_header"><code>ncr</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/sgd_shapley.py#L40" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ncr</code>(<strong><code>n</code></strong>, <strong><code>r</code></strong>)</p>
 </blockquote>
 <p>Combinatorial computation: number of subsets of size r among n elements
 Efficient algorithm</p>
@@ -206,7 +206,7 @@ Efficient algorithm</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="SGDshapley" class="doc_header"><code>class</code> <code>SGDshapley</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/sgd_shapley.py#L51" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>SGDshapley</code>(<strong><code>d</code></strong>, <strong><code>C</code></strong>)</p>
+<h2 id="SGDshapley" class="doc_header"><code>class</code> <code>SGDshapley</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/sgd_shapley.py#L51" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>SGDshapley</code>(<strong><code>d</code></strong>, <strong><code>C</code></strong>)</p>
 </blockquote>
 <p>Estimate the Shapley Values using a Projected Stochastic Gradient algorithm.</p>
 
@@ -231,7 +231,7 @@ Efficient algorithm</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="SGDshapley.sgd" class="doc_header"><code>SGDshapley.sgd</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/sgd_shapley.py#L137" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>SGDshapley.sgd</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>n_iter</code></strong>=<em><code>100</code></em>, <strong><code>step</code></strong>=<em><code>0.1</code></em>, <strong><code>step_type</code></strong>=<em><code>'sqrt'</code></em>, <strong><code>callback</code></strong>=<em><code>None</code></em>, <strong><code>Φ_0</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="SGDshapley.sgd" class="doc_header"><code>SGDshapley.sgd</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/sgd_shapley.py#L137" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>SGDshapley.sgd</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>, <strong><code>n_iter</code></strong>=<em><code>100</code></em>, <strong><code>step</code></strong>=<em><code>0.1</code></em>, <strong><code>step_type</code></strong>=<em><code>'sqrt'</code></em>, <strong><code>callback</code></strong>=<em><code>None</code></em>, <strong><code>Φ_0</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Stochastic gradient descent algorithm
 The game is defined for an element x, a reference r and function fc</p>

--- a/docs/shapley_values.html
+++ b/docs/shapley_values.html
@@ -124,7 +124,7 @@ $$ z(\mathbf{x^*},\mathbf{r},S) = (z_1,\dots, z_d) \text{ with } z_i =  x_i^* \t
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ShapleyValues" class="doc_header"><code>ShapleyValues</code><a href="https://github.com/sgrah-oss/shapkit/tree/master/shapkit/shapley_values.py#L39" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ShapleyValues</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>)</p>
+<h4 id="ShapleyValues" class="doc_header"><code>ShapleyValues</code><a href="https://github.com/ThalesGroup/shapkit/tree/master/shapkit/shapley_values.py#L39" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ShapleyValues</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>ref</code></strong>)</p>
 </blockquote>
 <p>Calculate the exact Shapley Values for an individual x
 in a game based on a reference r and the reward function fc.</p>


### PR DESCRIPTION
This updates another set of links.

Executing a `grep -r` I also got the following entry:
```
docs/shapleyvalues.html:<h4 id="ShapleyValues" class="doc_header"><code>ShapleyValues</code><a href="https://github.com/simon.grah/shapkit_nbdev/tree/master/shapkit_nbdev/shapleyvalues.py#L13" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ShapleyValues</code>(<strong><code>x</code></strong>, <strong><code>fc</code></strong>, <strong><code>r</code></strong>)</p>
```

However this is a link to `shapkit_nbdev` (different repo) so I left that one unchanged. However, the repo is inaccessible / does not exist so this link should most certainly be updated.

/cc @ThalesGroup/shapkit-maintainers 